### PR TITLE
[BE/fix] 문항 라이브러리의 문항 리스트 조회 기능 에러 해결

### DIFF
--- a/backend/src/main/java/com/jackpot/narratix/domain/controller/LibraryController.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/controller/LibraryController.java
@@ -8,8 +8,6 @@ import com.jackpot.narratix.domain.entity.enums.LibraryType;
 import com.jackpot.narratix.domain.entity.enums.QuestionCategoryType;
 import com.jackpot.narratix.domain.service.LibraryService;
 import com.jackpot.narratix.global.auth.UserId;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,8 +36,8 @@ public class LibraryController implements LibraryApi {
     @Override
     public ResponseEntity<CompanyLibraryResponse> getCompanyLibraries(
             @UserId String userId,
-            @RequestParam @NotBlank String companyName,
-            @RequestParam(defaultValue = "10") @Min(1) int size,
+            @RequestParam String companyName,
+            @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) Optional<Long> lastCoverLetterId
     ) {
         return ResponseEntity.ok(
@@ -50,8 +48,8 @@ public class LibraryController implements LibraryApi {
     @Override
     public ResponseEntity<QuestionLibraryResponse> getQuestionLibraries(
             @UserId String userId,
-            @RequestParam @NotBlank String questionCategory,
-            @RequestParam(defaultValue = "10") @Min(1) int size,
+            @RequestParam String questionCategory,
+            @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) Optional<Long> lastQuestionId
     ) {
         QuestionCategoryType questionCategoryType = QuestionCategoryType.fromDescription(questionCategory);


### PR DESCRIPTION
## 📝 PR Summary
문항유형 라이브러리의 문항 리스트 조회 api에서 500 에러를 반환하는 에러를 해결했습니다.

## 🌴 Works
- [x] 에러 원인 확인 : API 인터페이스를 도입하면서 libraryApi 인터페이스와 libraryController에서 파라미터 검증을 중복으로 정의하여 생긴 문제
- [x] 해결 : 검증 어노테이션은 인터페이스에서만 사용하도록 수정
 
🌱 Related Issue
#349 

## 📸 스크린샷 (선택)
500에러 없이 정상 작동하는 것을 확인했습니다. 
<img width="2526" height="1574" alt="image" src="https://github.com/user-attachments/assets/92f4f53a-c5e7-4e75-8a34-aca47baac6c2" />


## 🌵 PR 참고사항
- 프론트측에서 발견한 에러로 빠르게 해결하고자 합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 라이브러리 API 엔드포인트의 파라미터 유효성 검사가 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->