### PR TITLE
[BE/fix] s3 권한 문제 해결

### DIFF
--- a/backend/src/main/java/com/jackpot/narratix/domain/service/UploadService.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/UploadService.java
@@ -92,7 +92,7 @@ public class UploadService {
     }
 
     private String generateS3Key(String userId, String fileId) {
-        return "%s/%s/%s".formatted(FOLDER_NAME, userId, fileId);
+        return "%s/%s/%s.pdf".formatted(FOLDER_NAME, userId, fileId);
     }
 
     @Transactional
@@ -121,9 +121,11 @@ public class UploadService {
 
     private String extractFileId(String fileKey) {
         int lastSlashIndex = fileKey.lastIndexOf("/");
-
-        if (lastSlashIndex != -1 && lastSlashIndex < fileKey.length() - 1) {
-            return fileKey.substring(lastSlashIndex + 1);
+        String fileName = (lastSlashIndex != -1 && lastSlashIndex < fileKey.length() - 1)
+                ? fileKey.substring(lastSlashIndex + 1)
+                : fileKey;
+        if (fileName.toLowerCase().endsWith(".pdf")) {
+            return fileName.substring(0, fileName.length() - 4);
         }
         throw new BaseException(UploadErrorCode.INVALID_FILE_KEY);
     }


### PR DESCRIPTION
## 📝 PR Summary
S3 버킷 정책(Deny) 충돌로 인한 403 Forbidden 에러를 해결하고, 파일 업로드 시 확장자 관리를 자동화하는 로직을 수정했습니다.

## 🌴 Works
- [x] S3 Key 생성 로직 수정: generateS3Key 메서드에서 S3 정책(NotResource: *.pdf)을 통과할 수 있도록 파일 키 끝에 .pdf 확장자를 강제 추가

- [x] 파일 ID 추출 로직 : extractFileId 메서드에서 S3 Key로부터 순수 ID(ULID)만 추출할 수 있도록 확장자(.pdf) 제거 

🌱 Related Issue
closed #478 

## 📸 스크린샷 (선택)

## 🌵 PR 참고사항
빠른 에러 해결을 위해 종근님 리뷰 받고 머지하도록 하겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  - PDF 파일 업로드 시스템의 안정성이 개선되었습니다. 파일 인식 및 검증 기능이 더욱 견고해져 더 정확한 파일 처리가 가능해졌으며, 예외 상황에 대한 오류 감지 및 처리 능력이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->