### PR TITLE
[BE/refactor] SSE heart beat 주기 25초 -> 4초로 축소

### DIFF
--- a/backend/src/main/java/com/jackpot/narratix/global/sse/SseEmitterService.java
+++ b/backend/src/main/java/com/jackpot/narratix/global/sse/SseEmitterService.java
@@ -18,7 +18,7 @@ public class SseEmitterService {
 
     private static final int MAX_CONNECTIONS_PER_USER = 5;
     private static final long DEFAULT_TIMEOUT = 60 * 60 * 1000L; // 1시간
-    private static final long SSE_HEART_BEAT_TIMEOUT = 25 * 1000L; // 25초
+    private static final long SSE_HEART_BEAT_TIMEOUT = 4 * 1000L; // 4초
 
     private final SseEmitterRepository sseEmitterRepository;
 


### PR DESCRIPTION
## 📝 PR Summary
SSE에서 Client의 종료를 확인하기 위해서는 heart beat만 가능하다고 결론을 내렸기에 클라이언트의 재연결을 보장하기 위해 heart beat 주기를 25초에서 4초로 축소합니다.

## 🌴 Works
- [x] SSE heart beat 주기 25초 -> 4초로 축소

🌱 Related Issue
closed #550 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- SSE(Server-Sent Events) 기반 실시간 연결의 하트비트 체크 간격을 최적화하여 연결 안정성과 응답성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->