### PR TITLE
[FE/refactor] 제출일로 사용하는 Deadline 컴포넌트의 에러메시지 수정

### DIFF
--- a/frontend/src/features/upload/components/LabelingResultItem.tsx
+++ b/frontend/src/features/upload/components/LabelingResultItem.tsx
@@ -153,6 +153,7 @@ const LabelingResultItem = ({
               value={currentData.deadline}
               onChange={(value) => updateContents(tabState, 'deadline', value)}
               upload={true}
+              errorMessage='유효하지 않은 제출일입니다.'
             />
 
             <LabeledSelectInput

--- a/frontend/src/shared/components/Deadline.tsx
+++ b/frontend/src/shared/components/Deadline.tsx
@@ -8,9 +8,10 @@ interface Props {
   value?: string | Date;
   onChange: (value: string) => void;
   upload?: boolean;
+  errorMessage?: string;
 }
 
-const Deadline = ({ label, value, onChange, upload = false }: Props) => {
+const Deadline = ({ label, value, onChange, upload = false, errorMessage = '유효하지 않은 마감일입니다.' }: Props) => {
   const [isError, setIsError] = useState({
     year: false,
     month: false,
@@ -166,7 +167,7 @@ const Deadline = ({ label, value, onChange, upload = false }: Props) => {
             isIntegrationError ? 'opacity-100' : 'pointer-events-none opacity-0'
           } text-red-600`}
         >
-          유효하지 않은 마감일입니다.
+          {errorMessage}
         </span>
       </div>
 


### PR DESCRIPTION
## 📝 PR Summary
- 제출일로 사용하는 Deadline 컴포넌트의 에러메시지 수정

## 🌴 Works
- [X] Deadline 컴포넌트에 에러메시지를 props로 받아서 처리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **개선 사항**
  * 마감일 설정 시 유효성 검사 에러 메시지를 커스터마이즈할 수 있도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->