### PR TITLE
[BE/refactor] 좀비 락 제거 및 SessionRegistry를 Redis를 이용한 Registry로 확장

### DIFF
--- a/backend/src/main/java/com/jackpot/narratix/domain/service/ReviewService.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/ReviewService.java
@@ -35,7 +35,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
     private final QnARepository qnARepository;
-    private final ShareLinkSessionRegistry shareLinkSessionRegistry;
+    private final ShareLinkService shareLinkService;
 
     @Transactional
     public Review createReview(String reviewerId, Long qnAId, ReviewCreateRequest request) {
@@ -191,7 +191,7 @@ public class ReviewService {
     }
 
     public void validateWebSocketConnected(String userId, Long coverLetterId, ReviewRoleType role) {
-        if (!shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, coverLetterId, role)) {
+        if (!shareLinkService.isConnectedUserInCoverLetterId(userId, coverLetterId, role)) {
             throw new BaseException(GlobalErrorCode.FORBIDDEN);
         }
     }

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkLockManager.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkLockManager.java
@@ -76,10 +76,14 @@ public class ShareLinkLockManager {
         }
 
         String sessionKey = getSessionKey(sessionId);
-        redisTemplate.execute(UNLOCK_REDIS_SCRIPT, List.of(entry.getLockKey(), sessionKey), sessionId);
-        log.info("Lock released: sessionId={}, lockKey={}", sessionId, entry.getLockKey());
-    }
+        Long unlocked = redisTemplate.execute(UNLOCK_REDIS_SCRIPT, List.of(entry.getLockKey(), sessionKey), sessionId);
 
+        if (Long.valueOf(1L).equals(unlocked)) {
+            log.info("Lock released: sessionId={}, lockKey={}", sessionId, entry.getLockKey());
+        } else {
+            log.warn("Unlock skipped: sessionId={}, lockKey={},", sessionId, entry.getLockKey());
+        }
+    }
     /**
      * 모든 활성 세션의 분산락 TTL 갱신 (10초마다 호출)
      * 1. 좀비 세션(20초 무응답) 사전 필터링 및 제거

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkLockManager.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkLockManager.java
@@ -11,7 +11,6 @@ import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +27,17 @@ public class ShareLinkLockManager {
     private static final long ZOMBIE_THRESHOLD = 20_000L; // 20초간 응답 없으면 좀비로 간주
     private static final String LOCK_FORMAT = "share-link:lock:%s:%s"; // 첨삭 링크 인원 제한을 위함
     private static final String SESSION_KEY_FORMAT = "share-link:session:%s"; // 세션 아이디로 어떤 유저가 웹소켓에 연결되어 있는지 확인하기 위함
+
+    private static final String TRY_LOCK_SCRIPT = """
+            if redis.call('set', KEYS[1], ARGV[1], 'NX', 'EX', ARGV[3]) then
+                redis.call('set', KEYS[2], ARGV[2], 'EX', ARGV[3])
+                return 1
+            else
+                return 0
+            end
+            """;
+    private static final DefaultRedisScript<Long> TRY_LOCK_REDIS_SCRIPT =
+            new DefaultRedisScript<>(TRY_LOCK_SCRIPT, Long.class);
 
     // 내 락인 경우에만 삭제
     private static final String UNLOCK_SCRIPT = """
@@ -53,19 +63,25 @@ public class ShareLinkLockManager {
             """.getBytes(StandardCharsets.UTF_8);
     private static final byte[] LOCK_TIMEOUT_BYTES = String.valueOf(LOCK_TIMEOUT).getBytes(StandardCharsets.UTF_8);
 
+    private static final Long REDIS_TRUE = 1L;
     private static final int NUM_KEYS = 2;
 
     public boolean tryLock(String sessionId, String shareId, ReviewRoleType role, String userId) {
         String lockKey = getLockKey(shareId, role);
         String sessionKey = getSessionKey(sessionId);
 
-        Boolean success = redisTemplate.opsForValue().setIfAbsent(lockKey, sessionId, Duration.ofSeconds(LOCK_TIMEOUT));
-
-        if (Boolean.TRUE.equals(success)) {
-            redisTemplate.opsForValue().set(sessionKey, userId, Duration.ofSeconds(LOCK_TIMEOUT));
+        Long success = redisTemplate.execute(
+                TRY_LOCK_REDIS_SCRIPT,
+                List.of(lockKey, sessionKey),
+                sessionId,
+                userId,
+                String.valueOf(LOCK_TIMEOUT)
+        );
+        if (REDIS_TRUE.equals(success)) {
             sessionRegistry.register(sessionId, lockKey, userId);
+            return true;
         }
-        return Boolean.TRUE.equals(success);
+        return false;
     }
 
     public void unlock(String sessionId) {
@@ -78,12 +94,13 @@ public class ShareLinkLockManager {
         String sessionKey = getSessionKey(sessionId);
         Long unlocked = redisTemplate.execute(UNLOCK_REDIS_SCRIPT, List.of(entry.getLockKey(), sessionKey), sessionId);
 
-        if (Long.valueOf(1L).equals(unlocked)) {
+        if (REDIS_TRUE.equals(unlocked)) {
             log.info("Lock released: sessionId={}, lockKey={}", sessionId, entry.getLockKey());
         } else {
             log.warn("Unlock skipped: sessionId={}, lockKey={},", sessionId, entry.getLockKey());
         }
     }
+
     /**
      * 모든 활성 세션의 분산락 TTL 갱신 (10초마다 호출)
      * 1. 좀비 세션(20초 무응답) 사전 필터링 및 제거
@@ -133,11 +150,10 @@ public class ShareLinkLockManager {
             return null;
         });
 
-        // 3. Redis 연장 실패(이미 만료/유실된 락) 처리
+        // Redis 연장 실패(이미 만료/유실된 락) 처리
         for (int i = 0; i < validEntries.size(); i++) {
             Long result = (Long) results.get(i);
-            // Lua Script가 0을 반환했다면 갱신에 실패한 것임
-            if (result == null || result == 0L) {
+            if (!REDIS_TRUE.equals(result)) { // 갱신 실패: 락이 이미 만료되었거나 Redis에서 유실된 경우
                 Map.Entry<String, SessionEntry> entry = validEntries.get(i);
                 sessionRegistry.cleanUp(entry.getKey(), entry.getValue());
                 log.warn("Lock renewal failed (already expired in Redis), cleaned up: sessionId={}, lockKey={}"

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkLockManager.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkLockManager.java
@@ -1,6 +1,7 @@
 package com.jackpot.narratix.domain.service;
 
 import com.jackpot.narratix.domain.entity.enums.ReviewRoleType;
+import com.jackpot.narratix.domain.service.dto.SessionEntry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.ReturnType;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -22,101 +24,141 @@ public class ShareLinkLockManager {
     private final StringRedisTemplate redisTemplate;
     private final ShareLinkSessionRegistry sessionRegistry;
 
-    private static final long LOCK_TIMEOUT = 10L; // 10초
-    private static final String LOCK_FORMAT = "share-link:lock:%s:%s";
+    private static final long LOCK_TIMEOUT = 30L; // 30초
+    private static final long ZOMBIE_THRESHOLD = 20_000L; // 20초간 응답 없으면 좀비로 간주
+    private static final String LOCK_FORMAT = "share-link:lock:%s:%s"; // 첨삭 링크 인원 제한을 위함
+    private static final String SESSION_KEY_FORMAT = "share-link:session:%s"; // 세션 아이디로 어떤 유저가 웹소켓에 연결되어 있는지 확인하기 위함
 
     // 내 락인 경우에만 삭제
-    private static final String UNLOCK_SCRIPT
-            = """
+    private static final String UNLOCK_SCRIPT = """
             if redis.call('get', KEYS[1]) == ARGV[1] then
-                return redis.call('del', KEYS[1])
+                redis.call('del', KEYS[1])
+                redis.call('del', KEYS[2])
+                return 1
             else
                 return 0
             end
             """;
-    private static final DefaultRedisScript<Long> UNLOCK_REDIS_SCRIPT =
-            new DefaultRedisScript<>(UNLOCK_SCRIPT, Long.class);
+    private static final DefaultRedisScript<Long> UNLOCK_REDIS_SCRIPT = new DefaultRedisScript<>(UNLOCK_SCRIPT, Long.class);
 
     // 내 락인 경우에만 TTL 갱신
-    private static final byte[] RENEW_SCRIPT_BYTES
-            = """
+    private static final byte[] RENEW_SCRIPT_BYTES = """
             if redis.call('get', KEYS[1]) == ARGV[1] then
-                return redis.call('expire', KEYS[1], ARGV[2])
+                redis.call('expire', KEYS[1], ARGV[2])
+                redis.call('expire', KEYS[2], ARGV[2])
+                return 1
             else
                 return 0
             end
             """.getBytes(StandardCharsets.UTF_8);
-
     private static final byte[] LOCK_TIMEOUT_BYTES = String.valueOf(LOCK_TIMEOUT).getBytes(StandardCharsets.UTF_8);
 
-    private static final int NUM_KEYS = 1;
+    private static final int NUM_KEYS = 2;
 
     public boolean tryLock(String sessionId, String shareId, ReviewRoleType role, String userId) {
         String lockKey = getLockKey(shareId, role);
+        String sessionKey = getSessionKey(sessionId);
 
-        Boolean success = redisTemplate.opsForValue()
-                .setIfAbsent(lockKey, sessionId, Duration.ofSeconds(LOCK_TIMEOUT));
+        Boolean success = redisTemplate.opsForValue().setIfAbsent(lockKey, sessionId, Duration.ofSeconds(LOCK_TIMEOUT));
 
         if (Boolean.TRUE.equals(success)) {
+            redisTemplate.opsForValue().set(sessionKey, userId, Duration.ofSeconds(LOCK_TIMEOUT));
             sessionRegistry.register(sessionId, lockKey, userId);
-            log.info("Lock acquired: sessionId={}, shareId={}, role={}, userId={}", sessionId, shareId, role, userId);
         }
-
         return Boolean.TRUE.equals(success);
     }
 
-    /**
-     * sessionId로 락 해제 및 세션 목록에서 제거
-     * 락 값이 sessionId이므로 GET 없이 Lua Script 단일 호출로 원자적 해제
-     */
     public void unlock(String sessionId) {
-        ShareLinkSessionRegistry.SessionEntry entry = sessionRegistry.unregister(sessionId);
+        SessionEntry entry = sessionRegistry.unregister(sessionId);
         if (entry == null) {
             log.warn("No lock found for session: sessionId={}", sessionId);
             return;
         }
 
-        redisTemplate.execute(UNLOCK_REDIS_SCRIPT, List.of(entry.lockKey()), sessionId);
-        log.info("Lock released: sessionId={}, lockKey={}", sessionId, entry.lockKey());
+        String sessionKey = getSessionKey(sessionId);
+        redisTemplate.execute(UNLOCK_REDIS_SCRIPT, List.of(entry.getLockKey(), sessionKey), sessionId);
+        log.info("Lock released: sessionId={}, lockKey={}", sessionId, entry.getLockKey());
     }
 
     /**
-     * 모든 활성 세션의 분산락 TTL 갱신 (4초마다 호출)
-     * Pipeline + Lua Script로 단일 네트워크 IO에 소유권 검증 후 TTL 갱신
+     * 모든 활성 세션의 분산락 TTL 갱신 (10초마다 호출)
+     * 1. 좀비 세션(20초 무응답) 사전 필터링 및 제거
+     * 2. Pipeline + Lua Script로 단일 네트워크 IO에 소유권 검증 후 TTL 갱신 (Lock & Session 동시 갱신)
      */
     public void renewAllLocks() {
         if (sessionRegistry.isEmpty()) return;
 
-        // 순서 보존을 위해 엔트리 스냅샷 생성
-        List<Map.Entry<String, ShareLinkSessionRegistry.SessionEntry>> entries = sessionRegistry.getAllEntries();
+        long now = System.currentTimeMillis();
 
+        // 갱신할 유효 세션만 담을 리스트
+        List<Map.Entry<String, SessionEntry>> validEntries = new ArrayList<>();
+
+        // 좀비 세션 필터링
+        for (Map.Entry<String, SessionEntry> entry : sessionRegistry.getAllEntries()) {
+            String sessionId = entry.getKey();
+            SessionEntry sessionEntry = entry.getValue();
+
+            // 클라이언트가 20초 이상 활동이 없었다면 좀비로 간주하고 갱신 대상에서 제외
+            if (now - sessionEntry.getLastActiveTime() > ZOMBIE_THRESHOLD) {
+                log.warn("Zombie session detected. Stop renewing: sessionId={}, lockKey={}", sessionId, sessionEntry.getLockKey());
+                sessionRegistry.cleanUp(sessionId, sessionEntry); // 로컬에서 삭제
+                continue;
+            }
+            validEntries.add(entry);
+        }
+
+        if (validEntries.isEmpty()) return;
+
+        // 유효한 세션들만 Pipeline으로 일괄 갱신
         List<Object> results = redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
-            for (Map.Entry<String, ShareLinkSessionRegistry.SessionEntry> entry : entries) {
+            for (Map.Entry<String, SessionEntry> entry : validEntries) {
+                String sessionId = entry.getKey();
+                String lockKey = entry.getValue().getLockKey();
+                String sessionKey = getSessionKey(sessionId);
+
                 connection.scriptingCommands().eval(
                         RENEW_SCRIPT_BYTES,
                         ReturnType.INTEGER,
-                        NUM_KEYS, // Lua EVAL 명령에서 KEYS 배열의 크기, numKeys 이후 인자 중 앞 numKeys 개는 KEYS, 나머지는 ARGV로 분류
-                        entry.getValue().lockKey().getBytes(StandardCharsets.UTF_8), // KEYS[1] = lockKey
-                        entry.getKey().getBytes(StandardCharsets.UTF_8),              // ARGV[1] = sessionId
-                        LOCK_TIMEOUT_BYTES                                             // ARGV[2] = timeout
+                        NUM_KEYS,
+                        lockKey.getBytes(StandardCharsets.UTF_8),    // KEYS[1] = lockKey
+                        sessionKey.getBytes(StandardCharsets.UTF_8), // KEYS[2] = sessionKey
+                        sessionId.getBytes(StandardCharsets.UTF_8),  // ARGV[1] = sessionId
+                        LOCK_TIMEOUT_BYTES                           // ARGV[2] = timeout
                 );
             }
             return null;
         });
 
-        // 갱신 실패한 세션의 인메모리 상태 정리
-        for (int i = 0; i < entries.size(); i++) {
+        // 3. Redis 연장 실패(이미 만료/유실된 락) 처리
+        for (int i = 0; i < validEntries.size(); i++) {
             Long result = (Long) results.get(i);
+            // Lua Script가 0을 반환했다면 갱신에 실패한 것임
             if (result == null || result == 0L) {
-                Map.Entry<String, ShareLinkSessionRegistry.SessionEntry> entry = entries.get(i);
+                Map.Entry<String, SessionEntry> entry = validEntries.get(i);
                 sessionRegistry.cleanUp(entry.getKey(), entry.getValue());
-                log.warn("Lock renewal failed, cleaned up: sessionId={}, lockKey={}", entry.getKey(), entry.getValue().lockKey());
+                log.warn("Lock renewal failed (already expired in Redis), cleaned up: sessionId={}, lockKey={}"
+                        , entry.getKey(), entry.getValue().getLockKey());
             }
         }
-        log.debug("Lock TTLs renewed for {} sessions via pipeline", entries.size());
+
+        log.debug("Lock TTLs renewed for {} sessions via pipeline", validEntries.size());
     }
 
-    static String getLockKey(String shareId, ReviewRoleType role) {
+    private String getLockKey(String shareId, ReviewRoleType role) {
         return LOCK_FORMAT.formatted(shareId, role);
+    }
+
+    public boolean isConnectedUserInCoverLetter(String userId, String shareId, ReviewRoleType role) {
+        String lockKey = getLockKey(shareId, role);
+        String ownerSessionId = redisTemplate.opsForValue().get(lockKey);
+
+        if (ownerSessionId == null) return false;
+
+        String connectedUserId = redisTemplate.opsForValue().get(getSessionKey(ownerSessionId));
+        return userId.equals(connectedUserId);
+    }
+
+    private String getSessionKey(String sessionId) {
+        return SESSION_KEY_FORMAT.formatted(sessionId);
     }
 }

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkLockManager.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkLockManager.java
@@ -161,4 +161,8 @@ public class ShareLinkLockManager {
     private String getSessionKey(String sessionId) {
         return SESSION_KEY_FORMAT.formatted(sessionId);
     }
+
+    public void updateActivity(String sessionId) {
+        sessionRegistry.updateActivity(sessionId);
+    }
 }

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkLockRenewalScheduler.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkLockRenewalScheduler.java
@@ -12,7 +12,7 @@ public class ShareLinkLockRenewalScheduler {
 
     private final ShareLinkLockManager shareLinkLockManager;
 
-    private static final long LOCK_RENEWAL_TIME = 4 * 1000L;
+    private static final long LOCK_RENEWAL_TIME = 10 * 1000L;
 
     @Scheduled(fixedRate = LOCK_RENEWAL_TIME)
     public void renewActiveLocks() {
@@ -21,6 +21,5 @@ public class ShareLinkLockRenewalScheduler {
         } catch (Exception e) {
             log.error("락 갱신 중 예외 발생", e);
         }
-
     }
 }

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkService.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkService.java
@@ -38,7 +38,6 @@ public class ShareLinkService {
 
     private final WebSocketMessageSender webSocketMessageSender;
     private final ShareLinkLockManager shareLinkLockManager;
-    private final ShareLinkSessionRegistry shareLinkSessionRegistry;
     private final TextDeltaService textDeltaService;
     private final TextSyncService textSyncService;
 
@@ -200,7 +199,7 @@ public class ShareLinkService {
     }
 
     private void validateWebSocketConnected(String userId, String shareId, ReviewRoleType role) {
-        if (!shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, shareId, role)) {
+        if (!shareLinkLockManager.isConnectedUserInCoverLetter(userId, shareId, role)) {
             throw new BaseException(GlobalErrorCode.FORBIDDEN);
         }
     }
@@ -221,7 +220,11 @@ public class ShareLinkService {
         return shareLinkRepository.findByCoverLetterId(coverLetterId)
                 .filter(ShareLink::isValid)
                 .map(ShareLink::getShareId)
-                .map(shareId -> shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, shareId, role))
+                .map(shareId -> shareLinkLockManager.isConnectedUserInCoverLetter(userId, shareId, role))
                 .orElse(false);
+    }
+
+    public void updateActivity(String sessionId) {
+        shareLinkLockManager.updateActivity(sessionId);
     }
 }

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkService.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkService.java
@@ -215,4 +215,13 @@ public class ShareLinkService {
         }
         return shareLink;
     }
+
+    @Transactional(readOnly = true)
+    public boolean isConnectedUserInCoverLetterId(String userId, Long coverLetterId, ReviewRoleType role) {
+        return shareLinkRepository.findByCoverLetterId(coverLetterId)
+                .filter(ShareLink::isValid)
+                .map(ShareLink::getShareId)
+                .map(shareId -> shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, shareId, role))
+                .orElse(false);
+    }
 }

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkSessionRegistry.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkSessionRegistry.java
@@ -1,12 +1,9 @@
 package com.jackpot.narratix.domain.service;
 
-import com.jackpot.narratix.domain.entity.ShareLink;
 import com.jackpot.narratix.domain.entity.enums.ReviewRoleType;
-import com.jackpot.narratix.domain.repository.ShareLinkRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -25,8 +22,6 @@ import static com.jackpot.narratix.domain.service.ShareLinkLockManager.getLockKe
 @Component
 @RequiredArgsConstructor
 public class ShareLinkSessionRegistry {
-
-    private final ShareLinkRepository shareLinkRepository;
 
     // key: sessionId, value: SessionEntry(lockKey, userId)
     private final Map<String, SessionEntry> sessionEntries = new ConcurrentHashMap<>();
@@ -59,20 +54,6 @@ public class ShareLinkSessionRegistry {
         String ownerSessionId = lockOwners.get(lockKey);
         if (ownerSessionId == null) return Optional.empty();
         return Optional.ofNullable(sessionEntries.get(ownerSessionId)).map(SessionEntry::userId);
-    }
-
-    @Transactional(readOnly = true)
-    public boolean isConnectedUserInCoverLetter(String userId, Long coverLetterId, ReviewRoleType role) {
-        return findValidShareId(coverLetterId)
-                .flatMap(shareId -> findConnectedUserId(shareId, role))
-                .map(userId::equals)
-                .orElse(false);
-    }
-
-    private Optional<String> findValidShareId(Long coverLetterId) {
-        return shareLinkRepository.findByCoverLetterId(coverLetterId)
-                .filter(ShareLink::isValid)
-                .map(ShareLink::getShareId);
     }
 
     public List<Map.Entry<String, SessionEntry>> getAllEntries() {

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkSessionRegistry.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/ShareLinkSessionRegistry.java
@@ -1,71 +1,54 @@
 package com.jackpot.narratix.domain.service;
 
-import com.jackpot.narratix.domain.entity.enums.ReviewRoleType;
+import com.jackpot.narratix.domain.service.dto.SessionEntry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static com.jackpot.narratix.domain.service.ShareLinkLockManager.getLockKey;
 
 /**
  * WebSocket 세션과 ShareLink 간의 연결 상태를 추적하는 레지스트리.
  * ShareLinkLockManager에서 락 획득/해제 시 호출되며,
  * 현재 웹소켓에 연결된 유저를 조회할 때 사용된다.
- * TODO: 수평 확장 시 Redis 기반의 세션 레지스트리로 전환
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ShareLinkSessionRegistry {
 
-    // key: sessionId, value: SessionEntry(lockKey, userId)
+    // key: sessionId, value: SessionEntry(lockKey, userId, lastActiveTime)
     private final Map<String, SessionEntry> sessionEntries = new ConcurrentHashMap<>();
-
-    // key: lockKey, value: sessionId (소유권 검증용)
-    private final Map<String, String> lockOwners = new ConcurrentHashMap<>();
-
-    public record SessionEntry(String lockKey, String userId) {}
 
     public void register(String sessionId, String lockKey, String userId) {
         sessionEntries.put(sessionId, new SessionEntry(lockKey, userId));
-        lockOwners.put(lockKey, sessionId);
     }
+
 
     public SessionEntry unregister(String sessionId) {
-        SessionEntry entry = sessionEntries.remove(sessionId);
-        if (entry != null) {
-            lockOwners.remove(entry.lockKey(), sessionId);
-        }
-        return entry;
-    }
-
-    public boolean isConnectedUserInCoverLetter(String userId, String shareId, ReviewRoleType role) {
-        Optional<String> connectedUserId = findConnectedUserId(shareId, role);
-        return connectedUserId.map(s -> s.equals(userId)).orElse(false);
-    }
-
-    private Optional<String> findConnectedUserId(String shareId, ReviewRoleType role) {
-        String lockKey = getLockKey(shareId, role);
-        String ownerSessionId = lockOwners.get(lockKey);
-        if (ownerSessionId == null) return Optional.empty();
-        return Optional.ofNullable(sessionEntries.get(ownerSessionId)).map(SessionEntry::userId);
-    }
-
-    public List<Map.Entry<String, SessionEntry>> getAllEntries() {
-        return List.copyOf(sessionEntries.entrySet());
+        return sessionEntries.remove(sessionId);
     }
 
     public boolean isEmpty() {
         return sessionEntries.isEmpty();
     }
 
-    public void cleanUp(String sessionId, SessionEntry entry) {
-        sessionEntries.remove(sessionId, entry);
-        lockOwners.remove(entry.lockKey(), sessionId);
+    public List<Map.Entry<String, SessionEntry>> getAllEntries() {
+        return List.copyOf(sessionEntries.entrySet());
+    }
+
+    public void updateActivity(String sessionId) {
+        SessionEntry info = sessionEntries.get(sessionId);
+        if (info != null) {
+            info.updateActiveTime();
+        }
+    }
+
+    public void cleanUp(String sessionId, SessionEntry sessionEntry) {
+        if (sessionEntry != null) {
+            sessionEntries.remove(sessionId, sessionEntry);
+        }
     }
 }

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/TextDeltaService.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/TextDeltaService.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class TextDeltaService {
 
-    private static final int FLUSH_THRESHOLD = 100;
+    private static final int FLUSH_THRESHOLD = 20;
 
     private final TextDeltaRedisRepository textDeltaRedisRepository;
     private final QnARepository qnARepository;

--- a/backend/src/main/java/com/jackpot/narratix/domain/service/dto/SessionEntry.java
+++ b/backend/src/main/java/com/jackpot/narratix/domain/service/dto/SessionEntry.java
@@ -1,0 +1,20 @@
+package com.jackpot.narratix.domain.service.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SessionEntry {
+    private final String lockKey;
+    private final String userId;
+    private volatile long lastActiveTime;
+
+    public SessionEntry(String lockKey, String userId) {
+        this.lockKey = lockKey;
+        this.userId = userId;
+        this.lastActiveTime = System.currentTimeMillis();
+    }
+
+    public void updateActiveTime() {
+        this.lastActiveTime = System.currentTimeMillis();
+    }
+}

--- a/backend/src/main/java/com/jackpot/narratix/global/interceptor/StompChannelInterceptor.java
+++ b/backend/src/main/java/com/jackpot/narratix/global/interceptor/StompChannelInterceptor.java
@@ -49,6 +49,10 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
         }
 
+        if (accessor.getSessionId() != null) {
+            shareLinkService.updateActivity(accessor.getSessionId());
+        }
+
         return message;
     }
 
@@ -65,7 +69,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             suffixEndPoint = WRITER_SUBSCRIBE_ENDPOINT;
         } else if (role == ReviewRoleType.REVIEWER) {
             suffixEndPoint = REVIEWER_SUBSCRIBE_ENDPOINT;
-        } else{
+        } else {
             throw new BaseException(WebSocketErrorCode.ROLE_NOT_FOUND);
         }
 

--- a/backend/src/test/java/com/jackpot/narratix/domain/service/ShareLinkServiceTest.java
+++ b/backend/src/test/java/com/jackpot/narratix/domain/service/ShareLinkServiceTest.java
@@ -49,7 +49,7 @@ class ShareLinkServiceTest {
     private ShareLinkRepository shareLinkRepository;
 
     @Mock
-    private ShareLinkSessionRegistry shareLinkSessionRegistry;
+    private ShareLinkLockManager shareLinkLockManager;
 
     @Mock
     private TextSyncService textSyncService;
@@ -287,7 +287,7 @@ class ShareLinkServiceTest {
 
         given(qnARepository.findByIdOrElseThrow(qnAId)).willReturn(mockQnA);
         given(mockQnA.determineReviewRole(userId)).willReturn(ReviewRoleType.REVIEWER);
-        given(shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(true);
+        given(shareLinkLockManager.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(true);
         given(shareLinkRepository.findByShareId(shareId)).willReturn(Optional.of(mockShareLink));
         given(mockShareLink.isValid()).willReturn(true);
         given(mockShareLink.getCoverLetterId()).willReturn(coverLetterId);
@@ -322,7 +322,7 @@ class ShareLinkServiceTest {
         // getQnAWithVersion은 qnA 조회 → WebSocket 검증 → shareLink 검증 순서로 실행된다
         given(qnARepository.findByIdOrElseThrow(qnAId)).willReturn(mockQnA);
         given(mockQnA.determineReviewRole(userId)).willReturn(ReviewRoleType.REVIEWER);
-        given(shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(true);
+        given(shareLinkLockManager.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(true);
         given(shareLinkRepository.findByShareId(shareId)).willReturn(Optional.empty());
 
         // when & then
@@ -345,7 +345,7 @@ class ShareLinkServiceTest {
 
         given(qnARepository.findByIdOrElseThrow(qnAId)).willReturn(mockQnA);
         given(mockQnA.determineReviewRole(userId)).willReturn(ReviewRoleType.REVIEWER);
-        given(shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(true);
+        given(shareLinkLockManager.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(true);
         given(shareLinkRepository.findByShareId(shareId)).willReturn(Optional.of(mockShareLink));
         given(mockShareLink.isValid()).willReturn(false);
 
@@ -372,7 +372,7 @@ class ShareLinkServiceTest {
 
         given(qnARepository.findByIdOrElseThrow(qnAId)).willReturn(mockQnA);
         given(mockQnA.determineReviewRole(userId)).willReturn(ReviewRoleType.REVIEWER);
-        given(shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(true);
+        given(shareLinkLockManager.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(true);
         given(shareLinkRepository.findByShareId(shareId)).willReturn(Optional.of(mockShareLink));
         given(mockShareLink.isValid()).willReturn(true);
         given(mockShareLink.getCoverLetterId()).willReturn(shareLinkCoverLetterId);
@@ -402,7 +402,7 @@ class ShareLinkServiceTest {
         given(mockShareLink.getCoverLetterId()).willReturn(coverLetterId);
         given(coverLetterRepository.findByIdOrElseThrow(coverLetterId)).willReturn(mockCoverLetter);
         given(mockCoverLetter.determineReviewRole(userId)).willReturn(ReviewRoleType.REVIEWER);
-        given(shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(true);
+        given(shareLinkLockManager.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(true);
         given(mockCoverLetter.getId()).willReturn(coverLetterId);
         given(qnARepository.findIdsByCoverLetterId(coverLetterId)).willReturn(List.of(1L, 2L));
         given(mockCoverLetter.getCompanyName()).willReturn("테스트 기업");
@@ -466,7 +466,7 @@ class ShareLinkServiceTest {
 
         given(qnARepository.findByIdOrElseThrow(qnAId)).willReturn(mockQnA);
         given(mockQnA.determineReviewRole(userId)).willReturn(ReviewRoleType.REVIEWER);
-        given(shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(false);
+        given(shareLinkLockManager.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(false);
 
         // when & then
         assertThatThrownBy(() -> shareLinkService.getQnAWithVersion(userId, shareId, qnAId))
@@ -493,7 +493,7 @@ class ShareLinkServiceTest {
         given(mockShareLink.getCoverLetterId()).willReturn(coverLetterId);
         given(coverLetterRepository.findByIdOrElseThrow(coverLetterId)).willReturn(mockCoverLetter);
         given(mockCoverLetter.determineReviewRole(userId)).willReturn(ReviewRoleType.REVIEWER);
-        given(shareLinkSessionRegistry.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(false);
+        given(shareLinkLockManager.isConnectedUserInCoverLetter(userId, shareId, ReviewRoleType.REVIEWER)).willReturn(false);
 
         // when & then
         assertThatThrownBy(() -> shareLinkService.getCoverLetterAndQnAIds(userId, shareId))


### PR DESCRIPTION
## 📝 PR Summary
### 좀비 락 문제 해결
이전에 웹소켓 연결 중에 잡고 있는 Redis 분산 락이 SessionDisconnectEvent가 누락되면, 인메모리에서 세션이 지워지지 않아 스케쥴러에서 Redis Lock의 TTL을 계속 연장하는 좀비 락 문제를 존재했습니다. 

이를 스케쥴러가 갱신을 시도하기 전에, 하트비트를 통해 전송된 클라이언트의 최근 활동 시간을 검사합니다. 이로 인해 만약 `DisconnectEvent`가 누락되더라도, 클라이언트가 20초 이상 아무런 통신이 없다면 스케줄러는 "이 유저는 비정상 종료되었다"고 판단하여 갱신을 포기하고 로컬 메모리에서 삭제합니다. 갱신이 멈추면 Redis의 Lock은 자연스럽게 TTL 만료로 소멸하므로 좀비 락이 원천 차단됩니다.

###  A 서버에 접속한 유저의 상태를 B 서버의 `isConnectedUserInCoverLetter` 함수가 알 수 없음
서버 이중화시에 A 서버에 접속한 유저의 상태를 B 서버의 isConnectedUserInCoverLetter 함수가 알 수 없기 때문에 분산환경에서 정상적으로 동작하지 않습니다. 분산환경에서도 정상적으로 동작하도록 코드를 수정했습니다.

자신의 서버와 연결되어 있는 웹소켓 세션(갱신을 책임져야 할 세션)만  SessionRegistry에 남겨두고, 실제 sessionId와 userId의 매핑 정보는 Redis에 저장해두었습니다.

이로 인해 어떤 서버로 API 요청이 들어오든, Redis에 저장된 sessionId - userId 매핑으로 세션의 userId를 조회할 수 있습니다.

만약, API 요청을 보내려는 서버가 세션 아이디를 갖고 있지 않더라도, shareId를 통해 sessionId를 알아내고, sessionId를 통해 userId를 가져와 연결되어 있는 유저를 확인할 수 있습니다.

### Redis IO 부하 문제 해결
기존 Lock TTL이 10초로 짧았기 때문에 스케줄러도 매우 짧은 주기(4초)로 돌아야 했고, 이는 Redis IO가 잦아지는 문제가 발생했습니다.

Redis IO 횟수와 `SessionDisconnectEvent`누락 시 복구 시간에 대한 트레이드 오프가 존재하지만, `SessionDisconnectEvent` 누락은 자주 발생하는 문제가 아니기 때문에, Redis IO 횟수를 줄이는 방향으로 설계했습니다. Redis Lock의 TTL을 30초로 늘리고, 스케줄러의 주기를 10초로 늘렸습니다. 또한 `Pipelining`과 `Lua Script`를 활용해 한 번의 네트워크 I/O로 모든 처리를 끝내도록 구현했습니다.

## 🌴 Works
- [x] 좀비 락 문제 해결
- [x] A 서버에 접속한 유저의 상태를 B 서버의 `isConnectedUserInCoverLetter` 함수가 알 수 있도록 수정
- [x] Redis IO 부하 문제 해결

🌱 Related Issue
closed #567 

## 스크린샷
<img width="1072" height="71" alt="image" src="https://github.com/user-attachments/assets/070329f8-2f7c-4e46-b3f7-dca9243df671" />
heartbeat가 10초마다 발생하는 것을 확인할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 공유 링크 세션 관리 안정성 향상: 연결 상태 검증과 활동 갱신이 강화되었습니다.
  * 좀비 세션 감지·정리 추가로 불필요한 리소스 점유 감소 및 잠금 관리 개선.

* **성능/동작 조정**
  * 세션 잠금 유지시간 및 갱신 주기 조정으로 동시성 신뢰성 강화.
  * 텍스트 델타 플러시 임계치 축소로 변경사항이 더 자주 저장되어 데이터 손실 위험 감소.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->